### PR TITLE
Update XSD schema definition to version 3.6

### DIFF
--- a/snippets/xml.json
+++ b/snippets/xml.json
@@ -524,7 +524,7 @@
             "    xmlns=\"http://www.liquibase.org/xml/ns/dbchangelog\"",
             "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"",
             "    xmlns:ext=\"http://www.liquibase.org/xml/ns/dbchangelog-ext\"",
-            "    xsi:schemaLocation=\"http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd",
+            "    xsi:schemaLocation=\"http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd",
             "    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd\">",
             "   ${0}",
             "</databaseChangeLog>"


### PR DESCRIPTION
There are several new features and bug fixes, e.g. the keyword clustered is now supported on createIndex.
With the old XSD referenced the XML parser will throw an error.